### PR TITLE
adjustment to manifestChange emit to accomidate noop-local cli changes

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -161,7 +161,9 @@ class Application extends EventEmitter {
     }).on('all', (event, file) => {
       const { base } = path.parse(file)
       if (base === 'Noopfile' || base === '.gitignore' || base === '.dockerignore') {
-        this.emit('manifestChange', file)
+        const components = this.manifests.find(manifest => manifest.filePath === file).components
+          .map(component => component.name)
+        this.emit('manifestChange', components, file)
       } else {
         const modifiedComponents = []
         for (const manifestPath in this.watching) {


### PR DESCRIPTION
Adjusted manifestChange event emitter to include list of components defined in the changed manifest file. This was done to accommodate new features in the noop-local cli.

When this PR is released, the version of noop-discovery used by noop-local will need to be updated accordingly.