### PR TITLE
Fixed event emitting for ignore files when present in root dir

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -159,9 +159,9 @@ class Application extends EventEmitter {
     this.watcher = chokidar.watch(this.rootPath, {
       ignored: (path) => this.checkIgnoreStatus(path)
     }).on('all', (event, file) => {
-      const { base } = path.parse(file)
+      const { dir, base } = path.parse(file)
       if (base === 'Noopfile' || base === '.gitignore' || base === '.dockerignore') {
-        const components = this.manifests.find(manifest => manifest.filePath === file).components
+        const components = this.manifests.find(manifest => manifest.filePath.startsWith(`${dir}/`)).components
           .map(component => component.name)
         this.emit('manifestChange', components, file)
       } else {


### PR DESCRIPTION
This PR fixes an issue that was introduced when adjusting the behavior of a `manifestChange` event in a prior PR.

This issue only impacted Noop Local when auto-reloading was enabled.