### PR TITLE
Remove file watching from Noop Discovery

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,25 +1,18 @@
 const path = require('path')
 const async = require('async')
-const chokidar = require('chokidar')
 const crypto = require('crypto')
 const fs = require('fs')
-const ignore = require('ignore')
 const Manifest = require('./manifest')
-const EventEmitter = require('events').EventEmitter
 
-class Application extends EventEmitter {
+class Application {
   constructor (rootPath, watch) {
-    super()
     this.id = crypto.createHash('sha256').update(rootPath).digest('hex').substr(0, 8)
     this.rootPath = rootPath
-    this.watch = watch
-    this.watcher = null
     this.components = {}
     this.resources = {}
     this.routes = []
     this.manifests = []
-    this.ignoring = {}
-    this.watching = {}
+    this.ignoreFiles = []
   }
 
   discover (done) {
@@ -29,18 +22,12 @@ class Application extends EventEmitter {
           done(null, files)
         })
       },
-      parseIgnore: ['findFiles', (results, done) => {
+      findManifests: ['findFiles', (results, done) => {
         async.filter(results.findFiles, (file, done) => {
-          const { base } = path.parse(file)
-          if (this.watch) {
-            if (base === 'Noopfile') {
-              done(null, true)
-            } else {
-              this.parseIgnore(file, done)
-            }
-          } else {
-            done(null, base === 'Noopfile')
+          if (path.parse(file).base !== 'Noopfile') {
+            this.ignoreFiles.push(file)
           }
+          done(null, path.parse(file).base === 'Noopfile')
         }, (err, results) => {
           if (err) {
             done(err)
@@ -49,8 +36,8 @@ class Application extends EventEmitter {
           }
         })
       }],
-      parseManifests: ['parseIgnore', (results, done) => {
-        async.each(results.parseIgnore, (manifestFile, done) => {
+      parseManifests: ['findManifests', (results, done) => {
+        async.each(results.findManifests, (manifestFile, done) => {
           const manifest = new Manifest(manifestFile, this)
           this.manifests.push(manifest)
           manifest.discover(done)
@@ -59,22 +46,12 @@ class Application extends EventEmitter {
       validateComponents: ['parseManifests', (results, done) => {
         async.each(this.components, (component, done) => {
           component.validate(done)
-          if (this.watch) {
-            this.parseComponents(component, done)
-          }
         }, done)
       }],
       validateResources: ['validateComponents', (results, done) => {
         async.each(this.resources, (resource, done) => {
           resource.validate(done)
         }, done)
-      }],
-      watchers: ['validateResources', (results, done) => {
-        if (this.watch) {
-          this.setupWatch(done)
-        } else {
-          done()
-        }
       }]
     }, done)
   }
@@ -85,7 +62,7 @@ class Application extends EventEmitter {
         Promise.all(files.map((file) => {
           if (file.isDirectory() && !(file.name === '.git' && dir === this.rootPath)) {
             return this.recursiveSearch(path.resolve(dir, file.name), done)
-          } else if (file.name === 'Noopfile' || file.name === '.gitignore' || file.name === '.dockerignore') {
+          } else if (file.name === 'Noopfile' || file.name === '.gitignore') {
             return path.resolve(dir, file.name)
           } else {
             return false
@@ -97,121 +74,12 @@ class Application extends EventEmitter {
       .catch((err) => done(err))
   }
 
-  parseIgnore (file, done) {
-    fs.readFile(file, (err, data) => {
-      if (err) return done(err)
-      const files = new Set()
-      data.toString().split(/\r?\n/).forEach(line => {
-        const trimmed = line.trim()
-        if (trimmed.length && !trimmed.startsWith('#')) {
-          files.add(trimmed)
-        }
-      })
-      if (files.size > 0) {
-        this.ignoring[file] = { ig: ignore().add(Array.from(files)) }
-      }
-      done(null, false)
-    })
-  }
-
-  parseComponents (component, done) {
-    const files = new Set()
-    let watchAll = false
-    component.directives.forEach((directive) => {
-      if ((directive.cmd === 'ADD' || directive.cmd === 'COPY') && (directive.args.length === 2)) {
-        if (!watchAll) {
-          if (directive.args[0] === '.' || directive.args[0] === './') {
-            watchAll = true
-          } else {
-            files.add(directive.args[0])
-          }
-        }
-      }
-    })
-    if (files.size) {
-      const ig = ignore().add(watchAll ? '*' : Array.from(files))
-      if (component.rootPath in this.watching) {
-        this.watching[component.rootPath][component.name] = { ig }
-      } else {
-        this.watching[component.rootPath] = { [component.name]: { ig } }
-      }
-    }
-  }
-
   reload (done) {
     this.components = {}
     this.resources = {}
     this.routes = []
     this.manifests = []
-    if (this.watcher) {
-      this.watcher.close().then(() => {
-        this.watcher = null
-        this.ignoring = {}
-        this.watching = {}
-        this.discover(done)
-      })
-    } else {
-      this.discover(done)
-    }
-  }
-
-  setupWatch (done) {
-    this.watcher = chokidar.watch(this.rootPath, {
-      ignored: (path) => this.checkIgnoreStatus(path)
-    }).on('all', (event, file) => {
-      const { dir, base } = path.parse(file)
-      if (base === 'Noopfile') {
-        const components = this.manifests.find(manifest =>
-          manifest.filePath === file
-        ).components.map(component => component.name)
-        this.emit('manifestChange', components, file)
-      } else if (base === '.gitignore' || base === '.dockerignore') {
-        const components = Object.values(this.components).filter(component =>
-          `${dir}/`.startsWith(component.rootPath) || component.rootPath.startsWith(`${dir}/`)
-        ).map(component => component.name)
-        this.emit('manifestChange', components, file)
-      } else {
-        const modifiedComponents = []
-        for (const manifestPath in this.watching) {
-          if (file.startsWith(manifestPath)) {
-            for (const component in this.watching[manifestPath]) {
-              if (this.watching[manifestPath][component].ig.ignores(file.slice(manifestPath.length))) {
-                modifiedComponents.push(this.components[component])
-              }
-            }
-          }
-        }
-        if (modifiedComponents.length) {
-          modifiedComponents.forEach((component) => {
-            this.emit('componentChange', component.name, file)
-          })
-        }
-      }
-    })
-    done()
-  }
-
-  checkIgnoreStatus (file) {
-    if (file.includes('/.git/')) return true
-    if (file === this.rootPath || (new Set(['Noopfile', '.gitignore', '.dockerignore'])).has(path.parse(file).base)) return false
-    for (const key in this.ignoring) {
-      const keyDir = path.parse(key).dir + '/'
-      if (file.startsWith(keyDir)) {
-        if (this.ignoring[key].ig.ignores(file.slice(keyDir.length))) {
-          return true
-        }
-      }
-    }
-    for (const key in this.watching) {
-      if (file.startsWith(key)) {
-        for (const component in this.watching[key]) {
-          if (this.watching[key][component].ig.ignores(file.slice(key.length))) {
-            return false
-          }
-        }
-      }
-    }
-    return true
+    this.discover(done)
   }
 
   simple () { // deprecated

--- a/lib/app.js
+++ b/lib/app.js
@@ -159,9 +159,9 @@ class Application extends EventEmitter {
     this.watcher = chokidar.watch(this.rootPath, {
       ignored: (path) => this.checkIgnoreStatus(path)
     }).on('all', (event, file) => {
-      const { base } = path.parse(file)
+      const { dir, base } = path.parse(file)
       if (base === 'Noopfile' || base === '.gitignore' || base === '.dockerignore') {
-        const components = this.manifests.find(manifest => manifest.filePath === file).components
+        const components = this.manifests.find(manifest => manifest.filePath.startsWith(`${dir}/`)).components
           .map(component => component.name)
         this.emit('manifestChange', components, file)
       } else {

--- a/lib/app.js
+++ b/lib/app.js
@@ -160,9 +160,15 @@ class Application extends EventEmitter {
       ignored: (path) => this.checkIgnoreStatus(path)
     }).on('all', (event, file) => {
       const { dir, base } = path.parse(file)
-      if (base === 'Noopfile' || base === '.gitignore' || base === '.dockerignore') {
-        const components = this.manifests.find(manifest => manifest.filePath.startsWith(`${dir}/`)).components
-          .map(component => component.name)
+      if (base === 'Noopfile') {
+        const components = this.manifests.find(manifest =>
+          manifest.filePath === file
+        ).components.map(component => component.name)
+        this.emit('manifestChange', components, file)
+      } else if (base === '.gitignore' || base === '.dockerignore') {
+        const components = Object.values(this.components).filter(component =>
+          `${dir}/`.startsWith(component.rootPath) || component.rootPath.startsWith(`${dir}/`)
+        ).map(component => component.name)
         this.emit('manifestChange', components, file)
       } else {
         const modifiedComponents = []
@@ -187,7 +193,7 @@ class Application extends EventEmitter {
 
   checkIgnoreStatus (file) {
     if (file.includes('/.git/')) return true
-    if (file === this.rootPath || path.parse(file).base === 'Noopfile') return false
+    if (file === this.rootPath || (new Set(['Noopfile', '.gitignore', '.dockerignore'])).has(path.parse(file).base)) return false
     for (const key in this.ignoring) {
       const keyDir = path.parse(key).dir + '/'
       if (file.startsWith(keyDir)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
       "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -78,7 +79,8 @@
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -94,6 +96,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -144,6 +147,7 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
       "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+      "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -292,6 +296,7 @@
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
             "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
             "is-regex": "^1.1.1",
             "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
@@ -306,8 +311,30 @@
           "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
           "requires": {
             "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.0",
             "has-symbols": "^1.0.1",
             "object-keys": "^1.1.1"
+          },
+          "dependencies": {
+            "es-abstract": {
+              "version": "1.18.0-next.1",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+              "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+              "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.1",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
+              }
+            }
           }
         }
       }
@@ -359,6 +386,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -392,6 +420,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -429,6 +458,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -464,11 +494,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -495,6 +520,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -518,7 +544,8 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -530,6 +557,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -540,10 +568,16 @@
       "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
       "dev": true
     },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -705,7 +739,8 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.8.0",
@@ -788,7 +823,8 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "promise.allsettled": {
       "version": "1.0.2",
@@ -816,6 +852,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
       "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -915,6 +952,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
   },
   "dependencies": {
     "async": "^2.6.3",
-    "chokidar": "^3.4.2",
     "docker-file-parser": "^1.0.5",
-    "ignore": "^5.1.8",
     "minimist": "^1.2.5",
     "node-cron": "^2.0.3"
   }


### PR DESCRIPTION
This PR removes file-watching related logic from Noop Local. File-watching is now being managed within Noop Local.

For the time being I've left the `watch` param in the constructor for the Application class, even though the `watch` param is no longer being used. This param can be safely removed once it's confirmed that its omission will not cause any issues throughout other Noop services.

This PR should be coordinated with the Noop Local PR that adds file-watching logic and dependencies to that package.