### PR TITLE
Remove watch param from Application class

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ Noop application source code discovery library. This library is hosted publicly 
 
 The library exports a single function with three parameters.
 - `rootPath` {string} - path to scan for Noop App
-- `watch` {boolean} - whether or not to emit events on file changes
 - `done` {callback} - yields {err} and {app}
 
 
@@ -15,7 +14,7 @@ npm install noop-discovery --save
 ```javascript
 const discovery = require('noop-discovery')
 
-discovery('/project/root', true, (err, app) => {
+discovery('/project/root', (err, app) => {
   if (err) console.log('bort', err)
   app.on('manifestChange', (manifestFile) => {})
   app.on('componentChange', (componentName) => {})

--- a/index.js
+++ b/index.js
@@ -3,11 +3,10 @@ const App = require('./lib/app')
 /**
  *
  * @param {string} root - root directory to discover
- * @param {boolean} watch - whether or not to watch for changes and emit events
  * @param {function} done - c
  */
-module.exports = (root, watch = false, done) => {
-  const app = new App(root, watch)
+module.exports = (root, done) => {
+  const app = new App(root)
   app.discover((err) => {
     if (err) return done(err)
     done(null, app)

--- a/lib/app.js
+++ b/lib/app.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const Manifest = require('./manifest')
 
 class Application {
-  constructor (rootPath, watch) {
+  constructor (rootPath) {
     this.id = crypto.createHash('sha256').update(rootPath).digest('hex').substr(0, 8)
     this.rootPath = rootPath
     this.components = {}


### PR DESCRIPTION
This PR removes the `watch` param from Noop Discovery. The watch param was used for filewatching, but since those actions are now being managed in Noop Local the presence of the watch param in Discovery is unneeded.

After this PR is released, additional PRs will be opened for projects that utilize the Noop Discovery package. 