### PR TITLE
Add Support for Missing HTTP Request Methods with ROUTE Directive

### DIFF
--- a/lib/directive.js
+++ b/lib/directive.js
@@ -23,7 +23,18 @@ const directives = {
     method: {
       option: 'method',
       alias: 'm',
-      enum: ['GET', 'PUT', 'POST', 'DELETE', 'ALL', 'OPTIONS'],
+      enum: [
+        'GET',
+        'HEAD',
+        'POST',
+        'PUT',
+        'DELETE',
+        'CONNECT',
+        'OPTIONS',
+        'TRACE',
+        'PATCH',
+        'ALL'
+      ],
       default: 'ALL'
     },
     private: {
@@ -191,14 +202,22 @@ class Directive {
 
   parse (done) {
     if (this.cmd === 'CRON' && !validate(this.args.join(' '))) {
-      return done(new DirectiveError(`Invalid schedule pattern for '${this.cmd}' at '${this.file}:${this.lineNumber}'`))
+      return done(
+        new DirectiveError(
+          `Invalid schedule pattern for '${this.cmd}' at '${this.file}:${this.lineNumber}'`
+        )
+      )
     }
     const props = directives[this.cmd]
     if (!props) {
-      return done(new DirectiveError(`Unknown directive '${this.cmd}' at '${this.file}:${this.lineNumber}'`))
+      return done(
+        new DirectiveError(
+          `Unknown directive '${this.cmd}' at '${this.file}:${this.lineNumber}'`
+        )
+      )
     }
     const argOpts = { string: [], boolean: [], alias: {} }
-    Object.keys(props).forEach((key) => {
+    Object.keys(props).forEach(key => {
       if (props[key].boolean) {
         argOpts.boolean.push(props[key].option)
       }
@@ -211,7 +230,7 @@ class Directive {
     if (!props) {
       return done(new DirectiveError(`Unknown directive '${this.cmd}'`))
     }
-    Object.keys(props).forEach((key) => {
+    Object.keys(props).forEach(key => {
       let value = null
       if (Number.isInteger(props[key].operand)) {
         value = args._[props[key].operand]
@@ -236,9 +255,13 @@ class Directive {
       this.params[key] = value
     })
     if (errors.length) {
-      const error = new DirectiveError(errors.map((err) => {
-        return `[${this.file}:${this.lineNumber}] ${err}`
-      }).join('\n'))
+      const error = new DirectiveError(
+        errors
+          .map(err => {
+            return `[${this.file}:${this.lineNumber}] ${err}`
+          })
+          .join('\n')
+      )
       done(error)
     } else {
       done(null, this)


### PR DESCRIPTION
Changes:
- Add `HEAD`, `CONNECT`, `TRACE` and `PATCH` ([Mozilla doc used for reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods))
- General Standard.js formatting on `lib/directive.js` file